### PR TITLE
root CA certificate creating works

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ ca_email_address: robert@meinit.nl
 ca_organization_name: Very little
 ca_organizational_unit_name: Even less
 ca_state_or_province_name: Utrecht
+ca_locality_name: Utrecht
 
 # There are two formats to request a key and certificate:
 # 1. With details: (Includes `name:`)
@@ -43,11 +44,16 @@ ca_publication_location: "{{ httpd_data_directory | default('/tmp') }}/pub"
 # ca_openssl_path: /my/preferred/path
 ca_openssl_path: "{{ _ca_openssl_path[ansible_os_family] | default(_ca_openssl_path['default']) }}"
 
+# config file name
+ca_openssl_config_file: openssl.cnf
+
 # The names of the generated files are set to a sane default, but if you need
 # to change the for your application, you can overwrite the values. These paths
 # are relative to `ca_openssl_path`.
 ca_private_path: private
 ca_certs_path: certs
-ca_privatekey_path: "{{ ca_private_path }}/ca.pem"
-ca_csr_path: ca.csr
+ca_requests_path: requests
+ca_newcerts_path: newcerts
+ca_privatekey_path: "{{ ca_private_path }}/ca.key"
+ca_csr_path: "{{ ca_requests_path }}/ca.csr"
 ca_certificate_path: "{{ ca_certs_path }}/ca.crt"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,18 @@
   loop:
     - "{{ ca_openssl_path }}/{{ ca_private_path }}"
     - "{{ ca_openssl_path }}/{{ ca_certs_path }}"
+    - "{{ ca_openssl_path }}/{{ ca_requests_path }}"
+    - "{{ ca_openssl_path }}/{{ ca_newcerts_path }}"
+
+- name: ensure ca database text file exists
+  file:
+    path: "{{ ca_openssl_path }}/index.txt"
+    state: touch
+
+- name: ensure openssl config file exists
+  template:
+    src: "{{ ca_openssl_config_file }}.j2"
+    dest: "{{ ca_openssl_path }}/{{ ca_openssl_config_file }}"
 
 - name: generate ca key
   openssl_privatekey:
@@ -31,13 +43,14 @@
     state_or_province_name: "{{ ca_state_or_province_name | default(omit) }}"
 
 - name: generate ca certificate
-  openssl_certificate:
-    path: "{{ ca_openssl_path }}/{{ ca_certificate_path }}"
-    privatekey_path: "{{ ca_openssl_path }}/{{ ca_privatekey_path }}"
-    privatekey_passphrase: "{{ ca_passphrase }}"
-    csr_path: "{{ ca_openssl_path }}/{{ ca_csr_path }}"
-    provider: selfsigned
-
+  command:
+    chdir: "{{ ca_openssl_path }}"
+    cmd: openssl ca -config {{ ca_openssl_config_file }} -create_serial
+      -out {{ ca_certificate_path }} -days 1095
+      -selfsign -extensions v3_ca
+      -key {{ ca_passphrase }} -batch -infiles {{ ca_csr_path }}
+    creates: "{{ ca_openssl_path }}/{{ ca_certificate_path }}"
+    
 - name: generate requested key
   openssl_privatekey:
     path: "{{ ca_openssl_path }}/{{ ca_private_path }}/{{ item.name | default(item) }}.pem"
@@ -65,18 +78,18 @@
   when:
     - ca_requests is defined
 
-- name: generate certificate
-  openssl_certificate:
-    privatekey_path: "{{ ca_openssl_path }}/{{ ca_private_path }}/{{ item.name | default(item) }}.pem"
-    path: "{{ ca_openssl_path }}/{{ ca_certs_path }}/{{ item.name | default(item) }}.crt"
-    csr_path: "{{ ca_openssl_path }}/{{ item.name | default(item) }}.csr"
-    privatekey_passphrase: "{{ item.passphrase | default(omit) }}"
-    provider: selfsigned
-  loop: "{{ ca_requests }}"
-  loop_control:
-    label: "{{ item.name | default(item) }}"
-  when:
-    - ca_requests is defined
+# - name: generate certificate
+#   openssl_certificate:
+#     privatekey_path: "{{ ca_openssl_path }}/{{ ca_private_path }}/{{ item.name | default(item) }}.pem"
+#     path: "{{ ca_openssl_path }}/{{ ca_certs_path }}/{{ item.name | default(item) }}.crt"
+#     csr_path: "{{ ca_openssl_path }}/{{ item.name | default(item) }}.csr"
+#     privatekey_passphrase: "{{ item.passphrase | default(omit) }}"
+#     provider: selfsigned
+#   loop: "{{ ca_requests }}"
+#   loop_control:
+#     label: "{{ item.name | default(item) }}"
+#   when:
+#     - ca_requests is defined
 
 - name: ensure publication location exists
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,10 +45,11 @@
 - name: generate ca certificate
   command:
     chdir: "{{ ca_openssl_path }}"
-    cmd: openssl ca -config {{ ca_openssl_config_file }} -create_serial
+    cmd: openssl ca -config {{ ca_openssl_config_file }} -key {{ ca_passphrase }} 
       -out {{ ca_certificate_path }} -days 1095
+      -create_serial
       -selfsign -extensions v3_ca
-      -key {{ ca_passphrase }} -batch -infiles {{ ca_csr_path }}
+      -batch -infiles {{ ca_csr_path }}
     creates: "{{ ca_openssl_path }}/{{ ca_certificate_path }}"
     
 - name: generate requested key
@@ -64,7 +65,7 @@
 
 - name: generate requested certificate signing request
   openssl_csr:
-    path: "{{ ca_openssl_path }}/{{ item.name | default(item) }}.csr"
+    path: "{{ ca_openssl_path }}/{{ ca_requests_path }}/{{ item.name | default(item) }}.csr"
     privatekey_path: "{{ ca_openssl_path }}/{{ ca_private_path }}/{{ item.name | default(item) }}.pem"
     privatekey_passphrase: "{{ item.passphrase | default(omit) }}"
     common_name: "{{ item.name | default(item) }}"
@@ -78,18 +79,30 @@
   when:
     - ca_requests is defined
 
-# - name: generate certificate
-#   openssl_certificate:
-#     privatekey_path: "{{ ca_openssl_path }}/{{ ca_private_path }}/{{ item.name | default(item) }}.pem"
-#     path: "{{ ca_openssl_path }}/{{ ca_certs_path }}/{{ item.name | default(item) }}.crt"
-#     csr_path: "{{ ca_openssl_path }}/{{ item.name | default(item) }}.csr"
-#     privatekey_passphrase: "{{ item.passphrase | default(omit) }}"
-#     provider: selfsigned
-#   loop: "{{ ca_requests }}"
-#   loop_control:
-#     label: "{{ item.name | default(item) }}"
-#   when:
-#     - ca_requests is defined
+- name: generate requested certificate extension files
+  template:
+    src: extensions.cnf.j2
+    dest: "{{ ca_openssl_path }}/{{ item.name }}.cnf"
+  loop: "{{ ca_requests }}"
+  loop_control:
+    label: "{{ item.name | default(item) }}"
+  when:
+    - ca_requests is defined
+
+- name: generate requested certificate
+  command:
+    chdir: "{{ ca_openssl_path }}"
+    cmd: openssl ca -config {{ ca_openssl_config_file }} -key {{ ca_passphrase }}
+      -out {{ ca_certs_path }}/{{ item.name }}.crt
+      -policy policy_anything
+      -extfile {{ item.name }}.cnf -extensions x509_extensions
+      -batch -infiles {{ ca_requests_path }}/{{ item.name }}.csr
+    creates: "{{ ca_openssl_path }}/{{ ca_certs_path }}/{{ item.name }}.crt"
+  loop: "{{ ca_requests }}"
+  loop_control:
+    label: "{{ item.name | default(item) }}"
+  when:
+    - ca_requests is defined
 
 - name: ensure publication location exists
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,8 @@
   file:
     path: "{{ ca_openssl_path }}/index.txt"
     state: touch
+    modification_time: preserve
+    access_time: preserve
 
 - name: ensure openssl config file exists
   template:

--- a/templates/extensions.cnf.j2
+++ b/templates/extensions.cnf.j2
@@ -1,0 +1,56 @@
+[ x509_extensions ]
+
+# These extensions are added when 'ca' signs a request.
+
+{% for ext in item.extensions %}{{ ext }}
+{% endfor %}
+
+# This goes against PKIX guidelines but some CAs do it and some software
+# requires this to avoid interpreting an end user certificate as a CA.
+
+basicConstraints=CA:FALSE
+
+# Here are some examples of the usage of nsCertType. If it is omitted
+# the certificate can be used for anything *except* object signing.
+
+# This is OK for an SSL server.
+# nsCertType			= server
+
+# For an object signing certificate this would be used.
+# nsCertType = objsign
+
+# For normal client use this is typical
+# nsCertType = client, email
+
+# and for everything including object signing:
+# nsCertType = client, email, objsign
+
+# This is typical in keyUsage for a client certificate.
+# keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+# This will be displayed in Netscape's comment listbox.
+nsComment			= "OpenSSL Generated Certificate"
+
+# PKIX recommendations harmless if included in all certificates.
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+
+# This stuff is for subjectAltName and issuerAltname.
+# Import the email address.
+# subjectAltName=email:copy
+# An alternative to produce certificates that aren't
+# deprecated according to PKIX.
+# subjectAltName=email:move
+
+# Copy subject details
+# issuerAltName=issuer:copy
+
+#nsCaRevocationUrl		= http://www.domain.dom/ca-crl.pem
+#nsBaseUrl
+#nsRevocationUrl
+#nsRenewalUrl
+#nsCaPolicyUrl
+#nsSslServerName
+
+# This is required for TSA certificates.
+# extendedKeyUsage = critical,timeStamping

--- a/templates/openssl.cnf.j2
+++ b/templates/openssl.cnf.j2
@@ -1,0 +1,363 @@
+#
+# OpenSSL example configuration file.
+# This is mostly being used for generation of certificate requests.
+#
+
+# Note that you can include other files from the main configuration
+# file using the .include directive.
+#.include filename
+
+# This definition stops the following lines choking if HOME isn't
+# defined.
+HOME			= {{ ca_openssl_path }}
+
+# Extra OBJECT IDENTIFIER info:
+#oid_file		= $ENV::HOME/.oid
+oid_section		= new_oids
+
+# System default
+openssl_conf = default_conf
+
+# To use this configuration file with the "-extfile" option of the
+# "openssl x509" utility, name here the section containing the
+# X.509v3 extensions to use:
+# extensions		=
+# (Alternatively, use a configuration file that has only
+# X.509v3 extensions in its main [= default] section.)
+
+[ new_oids ]
+
+# We can add new OIDs in here for use by 'ca', 'req' and 'ts'.
+# Add a simple OID like this:
+# testoid1=1.2.3.4
+# Or use config file substitution like this:
+# testoid2=${testoid1}.5.6
+
+# Policies used by the TSA examples.
+tsa_policy1 = 1.2.3.4.1
+tsa_policy2 = 1.2.3.4.5.6
+tsa_policy3 = 1.2.3.4.5.7
+
+####################################################################
+[ ca ]
+default_ca	= CA_default		# The default ca section
+
+####################################################################
+[ CA_default ]
+
+dir		= {{ ca_openssl_path }}		# Where everything is kept
+certs		= $dir/{{ ca_certs_path }}	# Where the issued certs are kept
+crl_dir		= $dir/crl		# Where the issued crl are kept
+database	= $dir/index.txt	# database index file.
+#unique_subject	= no			# Set to 'no' to allow creation of
+# several certs with same subject.
+new_certs_dir	= $dir/{{ ca_newcerts_path }}		# default place for new certs.
+
+certificate	= $dir/{{ ca_certificate_path }}	# The CA certificate
+serial		= $dir/serial 		# The current serial number
+crlnumber	= $dir/crlnumber	# the current crl number
+# must be commented out to leave a V1 CRL
+crl		= $dir/crl.pem 		# The current CRL
+private_key	= $dir/{{ ca_privatekey_path }}	# The private key
+
+x509_extensions	= usr_cert		# The extensions to add to the cert
+
+# Comment out the following two lines for the "traditional"
+# (and highly broken) format.
+name_opt 	= ca_default		# Subject Name options
+cert_opt 	= ca_default		# Certificate field options
+
+# Extension copying option: use with caution.
+# copy_extensions = copy
+
+# Extensions to add to a CRL. Note: Netscape communicator chokes on V2 CRLs
+# so this is commented out by default to leave a V1 CRL.
+# crlnumber must also be commented out to leave a V1 CRL.
+# crl_extensions	= crl_ext
+
+default_days	= 365			# how long to certify for
+default_crl_days= 30			# how long before next CRL
+default_md	= default		# use public key default MD
+preserve	= no			# keep passed DN ordering
+
+# A few difference way of specifying how similar the request should look
+# For type CA, the listed attributes must be the same, and the optional
+# and supplied fields are just that :-)
+policy		= policy_match
+
+# For the CA policy
+[ policy_match ]
+countryName		= match
+stateOrProvinceName	= match
+organizationName	= match
+organizationalUnitName	= optional
+commonName		= supplied
+emailAddress		= optional
+
+# For the 'anything' policy
+# At this point in time, you must list all acceptable 'object'
+# types.
+[ policy_anything ]
+countryName		= optional
+stateOrProvinceName	= optional
+localityName		= optional
+organizationName	= optional
+organizationalUnitName	= optional
+commonName		= supplied
+emailAddress		= optional
+
+####################################################################
+[ req ]
+default_bits		= 2048
+default_keyfile 	= privkey.pem
+distinguished_name	= req_distinguished_name
+attributes		= req_attributes
+x509_extensions		= v3_ca	# The extensions to add to the self signed cert
+
+# Passwords for private keys if not present they will be prompted for
+# input_password = secret
+# output_password = secret
+
+# This sets a mask for permitted string types. There are several options.
+# default: PrintableString, T61String, BMPString.
+# pkix	 : PrintableString, BMPString (PKIX recommendation before 2004)
+# utf8only: only UTF8Strings (PKIX recommendation after 2004).
+# nombstr : PrintableString, T61String (no BMPStrings or UTF8Strings).
+# MASK:XXXX a literal mask value.
+# WARNING: ancient versions of Netscape crash on BMPStrings or UTF8Strings.
+string_mask = utf8only
+
+# req_extensions = v3_req # The extensions to add to a certificate request
+
+[ req_distinguished_name ]
+countryName			= Country Name (2 letter code)
+countryName_default		= {{ ca_country_name }}
+countryName_min			= 2
+countryName_max			= 2
+
+stateOrProvinceName		= State or Province Name (full name)
+stateOrProvinceName_default	= {{ ca_state_or_province_name }}
+
+localityName			= Locality Name (eg, city)
+localityName_default		= {{ ca_locality_name }}
+
+0.organizationName		= Organization Name (eg, company)
+0.organizationName_default	= {{ ca_organization_name }}
+
+# we can do this but it is not needed normally :-)
+#1.organizationName		= Second Organization Name (eg, company)
+#1.organizationName_default	= World Wide Web Pty Ltd
+
+organizationalUnitName		= Organizational Unit Name (eg, section)
+organizationalUnitName_default	= {{ ca_organizational_unit_name }}
+
+commonName			= Common Name (e.g. server FQDN or YOUR name)
+commonName_max			= 64
+
+emailAddress			= Email Address
+emailAddress_max		= 64
+
+# SET-ex3			= SET extension number 3
+
+[ req_attributes ]
+challengePassword		= A challenge password
+challengePassword_min		= 4
+challengePassword_max		= 20
+
+unstructuredName		= An optional company name
+
+[ usr_cert ]
+
+# These extensions are added when 'ca' signs a request.
+
+# This goes against PKIX guidelines but some CAs do it and some software
+# requires this to avoid interpreting an end user certificate as a CA.
+
+basicConstraints=CA:FALSE
+
+# Here are some examples of the usage of nsCertType. If it is omitted
+# the certificate can be used for anything *except* object signing.
+
+# This is OK for an SSL server.
+# nsCertType			= server
+
+# For an object signing certificate this would be used.
+# nsCertType = objsign
+
+# For normal client use this is typical
+nsCertType = client, email
+
+# and for everything including object signing:
+# nsCertType = client, email, objsign
+
+# This is typical in keyUsage for a client certificate.
+# keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+# This will be displayed in Netscape's comment listbox.
+nsComment			= "OpenSSL Generated Certificate"
+
+# PKIX recommendations harmless if included in all certificates.
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+
+# This stuff is for subjectAltName and issuerAltname.
+# Import the email address.
+# subjectAltName=email:copy
+# An alternative to produce certificates that aren't
+# deprecated according to PKIX.
+# subjectAltName=email:move
+
+# Copy subject details
+# issuerAltName=issuer:copy
+
+#nsCaRevocationUrl		= http://www.domain.dom/ca-crl.pem
+#nsBaseUrl
+#nsRevocationUrl
+#nsRenewalUrl
+#nsCaPolicyUrl
+#nsSslServerName
+
+# This is required for TSA certificates.
+# extendedKeyUsage = critical,timeStamping
+
+[ v3_req ]
+
+# Extensions to add to a certificate request
+
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+[ v3_ca ]
+
+
+# Extensions for a typical CA
+
+
+# PKIX recommendation.
+
+subjectKeyIdentifier=hash
+
+authorityKeyIdentifier=keyid:always,issuer
+
+basicConstraints = critical,CA:true
+
+# Key usage: this is typical for a CA certificate. However since it will
+# prevent it being used as an test self-signed certificate it is best
+# left out by default.
+keyUsage = cRLSign, keyCertSign
+
+# Some might want this also
+# nsCertType = sslCA, emailCA
+
+# Include email address in subject alt name: another PKIX recommendation
+# subjectAltName=email:copy
+# Copy issuer details
+# issuerAltName=issuer:copy
+
+# DER hex encoding of an extension: beware experts only!
+# obj=DER:02:03
+# Where 'obj' is a standard or added object
+# You can even override a supported extension:
+# basicConstraints= critical, DER:30:03:01:01:FF
+
+[ crl_ext ]
+
+# CRL extensions.
+# Only issuerAltName and authorityKeyIdentifier make any sense in a CRL.
+
+# issuerAltName=issuer:copy
+authorityKeyIdentifier=keyid:always
+
+[ proxy_cert_ext ]
+# These extensions should be added when creating a proxy certificate
+
+# This goes against PKIX guidelines but some CAs do it and some software
+# requires this to avoid interpreting an end user certificate as a CA.
+
+basicConstraints=CA:FALSE
+
+# Here are some examples of the usage of nsCertType. If it is omitted
+# the certificate can be used for anything *except* object signing.
+
+# This is OK for an SSL server.
+# nsCertType			= server
+
+# For an object signing certificate this would be used.
+# nsCertType = objsign
+
+# For normal client use this is typical
+# nsCertType = client, email
+
+# and for everything including object signing:
+# nsCertType = client, email, objsign
+
+# This is typical in keyUsage for a client certificate.
+# keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+# This will be displayed in Netscape's comment listbox.
+nsComment			= "OpenSSL Generated Certificate"
+
+# PKIX recommendations harmless if included in all certificates.
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+
+# This stuff is for subjectAltName and issuerAltname.
+# Import the email address.
+# subjectAltName=email:copy
+# An alternative to produce certificates that aren't
+# deprecated according to PKIX.
+# subjectAltName=email:move
+
+# Copy subject details
+# issuerAltName=issuer:copy
+
+#nsCaRevocationUrl		= http://www.domain.dom/ca-crl.pem
+#nsBaseUrl
+#nsRevocationUrl
+#nsRenewalUrl
+#nsCaPolicyUrl
+#nsSslServerName
+
+# This really needs to be in place for it to be a proxy certificate.
+proxyCertInfo=critical,language:id-ppl-anyLanguage,pathlen:3,policy:foo
+
+####################################################################
+[ tsa ]
+
+default_tsa = tsa_config1	# the default TSA section
+
+[ tsa_config1 ]
+
+# These are used by the TSA reply generation only.
+dir		= $HOME			# TSA root directory
+serial		= $dir/tsaserial	# The current serial number (mandatory)
+crypto_device	= builtin		# OpenSSL engine to use for signing
+signer_cert	= $dir/tsacert.pem 	# The TSA signing certificate
+# (optional)
+certs		= $dir/cacert.pem	# Certificate chain to include in reply
+# (optional)
+signer_key	= $dir/private/tsakey.pem # The TSA private key (optional)
+signer_digest  = sha256			# Signing digest to use. (Optional)
+default_policy	= tsa_policy1		# Policy if request did not specify it
+# (optional)
+other_policies	= tsa_policy2, tsa_policy3	# acceptable policies (optional)
+digests     = sha1, sha256, sha384, sha512  # Acceptable message digests (mandatory)
+accuracy	= secs:1, millisecs:500, microsecs:100	# (optional)
+clock_precision_digits  = 0	# number of digits after dot. (optional)
+ordering		= yes	# Is ordering defined for timestamps?
+# (optional, default: no)
+tsa_name		= yes	# Must the TSA name be included in the reply?
+# (optional, default: no)
+ess_cert_id_chain	= no	# Must the ESS cert id chain be included?
+# (optional, default: no)
+ess_cert_id_alg		= sha1	# algorithm to compute certificate
+# identifier (optional, default: sha1)
+[default_conf]
+ssl_conf = ssl_sect
+
+[ssl_sect]
+system_default = system_default_sect
+
+[system_default_sect]
+MinProtocol = TLSv1.2
+CipherString = DEFAULT@SECLEVEL=2

--- a/templates/openssl.cnf.j2~
+++ b/templates/openssl.cnf.j2~
@@ -1,0 +1,363 @@
+#
+# OpenSSL example configuration file.
+# This is mostly being used for generation of certificate requests.
+#
+
+# Note that you can include other files from the main configuration
+# file using the .include directive.
+#.include filename
+
+# This definition stops the following lines choking if HOME isn't
+# defined.
+HOME			= {{ ca_openssl_path }}
+
+# Extra OBJECT IDENTIFIER info:
+#oid_file		= $ENV::HOME/.oid
+oid_section		= new_oids
+
+# System default
+openssl_conf = default_conf
+
+# To use this configuration file with the "-extfile" option of the
+# "openssl x509" utility, name here the section containing the
+# X.509v3 extensions to use:
+# extensions		=
+# (Alternatively, use a configuration file that has only
+# X.509v3 extensions in its main [= default] section.)
+
+[ new_oids ]
+
+# We can add new OIDs in here for use by 'ca', 'req' and 'ts'.
+# Add a simple OID like this:
+# testoid1=1.2.3.4
+# Or use config file substitution like this:
+# testoid2=${testoid1}.5.6
+
+# Policies used by the TSA examples.
+tsa_policy1 = 1.2.3.4.1
+tsa_policy2 = 1.2.3.4.5.6
+tsa_policy3 = 1.2.3.4.5.7
+
+####################################################################
+[ ca ]
+default_ca	= CA_default		# The default ca section
+
+####################################################################
+[ CA_default ]
+
+dir		= {{ ca_openssl_path }}		# Where everything is kept
+certs		= $dir/{{ ca_certs_path }}	# Where the issued certs are kept
+crl_dir		= $dir/crl		# Where the issued crl are kept
+database	= $dir/index.txt	# database index file.
+#unique_subject	= no			# Set to 'no' to allow creation of
+# several certs with same subject.
+new_certs_dir	= $dir/{{ ca_newcerts_path }}		# default place for new certs.
+
+certificate	= {{ ca_certificate_path }}	# The CA certificate
+serial		= $dir/serial 		# The current serial number
+crlnumber	= $dir/crlnumber	# the current crl number
+# must be commented out to leave a V1 CRL
+crl		= $dir/crl.pem 		# The current CRL
+private_key	= {{ ca_privatekey_path }}	# The private key
+
+x509_extensions	= usr_cert		# The extensions to add to the cert
+
+# Comment out the following two lines for the "traditional"
+# (and highly broken) format.
+name_opt 	= ca_default		# Subject Name options
+cert_opt 	= ca_default		# Certificate field options
+
+# Extension copying option: use with caution.
+# copy_extensions = copy
+
+# Extensions to add to a CRL. Note: Netscape communicator chokes on V2 CRLs
+# so this is commented out by default to leave a V1 CRL.
+# crlnumber must also be commented out to leave a V1 CRL.
+# crl_extensions	= crl_ext
+
+default_days	= 365			# how long to certify for
+default_crl_days= 30			# how long before next CRL
+default_md	= default		# use public key default MD
+preserve	= no			# keep passed DN ordering
+
+# A few difference way of specifying how similar the request should look
+# For type CA, the listed attributes must be the same, and the optional
+# and supplied fields are just that :-)
+policy		= policy_match
+
+# For the CA policy
+[ policy_match ]
+countryName		= match
+stateOrProvinceName	= match
+organizationName	= match
+organizationalUnitName	= optional
+commonName		= supplied
+emailAddress		= optional
+
+# For the 'anything' policy
+# At this point in time, you must list all acceptable 'object'
+# types.
+[ policy_anything ]
+countryName		= optional
+stateOrProvinceName	= optional
+localityName		= optional
+organizationName	= optional
+organizationalUnitName	= optional
+commonName		= supplied
+emailAddress		= optional
+
+####################################################################
+[ req ]
+default_bits		= 2048
+default_keyfile 	= privkey.pem
+distinguished_name	= req_distinguished_name
+attributes		= req_attributes
+x509_extensions		= v3_ca	# The extensions to add to the self signed cert
+
+# Passwords for private keys if not present they will be prompted for
+# input_password = secret
+# output_password = secret
+
+# This sets a mask for permitted string types. There are several options.
+# default: PrintableString, T61String, BMPString.
+# pkix	 : PrintableString, BMPString (PKIX recommendation before 2004)
+# utf8only: only UTF8Strings (PKIX recommendation after 2004).
+# nombstr : PrintableString, T61String (no BMPStrings or UTF8Strings).
+# MASK:XXXX a literal mask value.
+# WARNING: ancient versions of Netscape crash on BMPStrings or UTF8Strings.
+string_mask = utf8only
+
+# req_extensions = v3_req # The extensions to add to a certificate request
+
+[ req_distinguished_name ]
+countryName			= Country Name (2 letter code)
+countryName_default		= {{ ca_country_name }}
+countryName_min			= 2
+countryName_max			= 2
+
+stateOrProvinceName		= State or Province Name (full name)
+stateOrProvinceName_default	= {{ ca_state_or_province_name }}
+
+localityName			= Locality Name (eg, city)
+localityName_default		= {{ ca_locality_name }}
+
+0.organizationName		= Organization Name (eg, company)
+0.organizationName_default	= {{ ca_organization_name }}
+
+# we can do this but it is not needed normally :-)
+#1.organizationName		= Second Organization Name (eg, company)
+#1.organizationName_default	= World Wide Web Pty Ltd
+
+organizationalUnitName		= Organizational Unit Name (eg, section)
+organizationalUnitName_default	= {{ ca_organizational_unit_name }}
+
+commonName			= Common Name (e.g. server FQDN or YOUR name)
+commonName_max			= 64
+
+emailAddress			= Email Address
+emailAddress_max		= 64
+
+# SET-ex3			= SET extension number 3
+
+[ req_attributes ]
+challengePassword		= A challenge password
+challengePassword_min		= 4
+challengePassword_max		= 20
+
+unstructuredName		= An optional company name
+
+[ usr_cert ]
+
+# These extensions are added when 'ca' signs a request.
+
+# This goes against PKIX guidelines but some CAs do it and some software
+# requires this to avoid interpreting an end user certificate as a CA.
+
+basicConstraints=CA:FALSE
+
+# Here are some examples of the usage of nsCertType. If it is omitted
+# the certificate can be used for anything *except* object signing.
+
+# This is OK for an SSL server.
+# nsCertType			= server
+
+# For an object signing certificate this would be used.
+# nsCertType = objsign
+
+# For normal client use this is typical
+nsCertType = client, email
+
+# and for everything including object signing:
+# nsCertType = client, email, objsign
+
+# This is typical in keyUsage for a client certificate.
+# keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+# This will be displayed in Netscape's comment listbox.
+nsComment			= "OpenSSL Generated Certificate"
+
+# PKIX recommendations harmless if included in all certificates.
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+
+# This stuff is for subjectAltName and issuerAltname.
+# Import the email address.
+# subjectAltName=email:copy
+# An alternative to produce certificates that aren't
+# deprecated according to PKIX.
+# subjectAltName=email:move
+
+# Copy subject details
+# issuerAltName=issuer:copy
+
+#nsCaRevocationUrl		= http://www.domain.dom/ca-crl.pem
+#nsBaseUrl
+#nsRevocationUrl
+#nsRenewalUrl
+#nsCaPolicyUrl
+#nsSslServerName
+
+# This is required for TSA certificates.
+# extendedKeyUsage = critical,timeStamping
+
+[ v3_req ]
+
+# Extensions to add to a certificate request
+
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+[ v3_ca ]
+
+
+# Extensions for a typical CA
+
+
+# PKIX recommendation.
+
+subjectKeyIdentifier=hash
+
+authorityKeyIdentifier=keyid:always,issuer
+
+basicConstraints = critical,CA:true
+
+# Key usage: this is typical for a CA certificate. However since it will
+# prevent it being used as an test self-signed certificate it is best
+# left out by default.
+keyUsage = cRLSign, keyCertSign
+
+# Some might want this also
+# nsCertType = sslCA, emailCA
+
+# Include email address in subject alt name: another PKIX recommendation
+# subjectAltName=email:copy
+# Copy issuer details
+# issuerAltName=issuer:copy
+
+# DER hex encoding of an extension: beware experts only!
+# obj=DER:02:03
+# Where 'obj' is a standard or added object
+# You can even override a supported extension:
+# basicConstraints= critical, DER:30:03:01:01:FF
+
+[ crl_ext ]
+
+# CRL extensions.
+# Only issuerAltName and authorityKeyIdentifier make any sense in a CRL.
+
+# issuerAltName=issuer:copy
+authorityKeyIdentifier=keyid:always
+
+[ proxy_cert_ext ]
+# These extensions should be added when creating a proxy certificate
+
+# This goes against PKIX guidelines but some CAs do it and some software
+# requires this to avoid interpreting an end user certificate as a CA.
+
+basicConstraints=CA:FALSE
+
+# Here are some examples of the usage of nsCertType. If it is omitted
+# the certificate can be used for anything *except* object signing.
+
+# This is OK for an SSL server.
+# nsCertType			= server
+
+# For an object signing certificate this would be used.
+# nsCertType = objsign
+
+# For normal client use this is typical
+# nsCertType = client, email
+
+# and for everything including object signing:
+# nsCertType = client, email, objsign
+
+# This is typical in keyUsage for a client certificate.
+# keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+# This will be displayed in Netscape's comment listbox.
+nsComment			= "OpenSSL Generated Certificate"
+
+# PKIX recommendations harmless if included in all certificates.
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+
+# This stuff is for subjectAltName and issuerAltname.
+# Import the email address.
+# subjectAltName=email:copy
+# An alternative to produce certificates that aren't
+# deprecated according to PKIX.
+# subjectAltName=email:move
+
+# Copy subject details
+# issuerAltName=issuer:copy
+
+#nsCaRevocationUrl		= http://www.domain.dom/ca-crl.pem
+#nsBaseUrl
+#nsRevocationUrl
+#nsRenewalUrl
+#nsCaPolicyUrl
+#nsSslServerName
+
+# This really needs to be in place for it to be a proxy certificate.
+proxyCertInfo=critical,language:id-ppl-anyLanguage,pathlen:3,policy:foo
+
+####################################################################
+[ tsa ]
+
+default_tsa = tsa_config1	# the default TSA section
+
+[ tsa_config1 ]
+
+# These are used by the TSA reply generation only.
+dir		= $HOME			# TSA root directory
+serial		= $dir/tsaserial	# The current serial number (mandatory)
+crypto_device	= builtin		# OpenSSL engine to use for signing
+signer_cert	= $dir/tsacert.pem 	# The TSA signing certificate
+# (optional)
+certs		= $dir/cacert.pem	# Certificate chain to include in reply
+# (optional)
+signer_key	= $dir/private/tsakey.pem # The TSA private key (optional)
+signer_digest  = sha256			# Signing digest to use. (Optional)
+default_policy	= tsa_policy1		# Policy if request did not specify it
+# (optional)
+other_policies	= tsa_policy2, tsa_policy3	# acceptable policies (optional)
+digests     = sha1, sha256, sha384, sha512  # Acceptable message digests (mandatory)
+accuracy	= secs:1, millisecs:500, microsecs:100	# (optional)
+clock_precision_digits  = 0	# number of digits after dot. (optional)
+ordering		= yes	# Is ordering defined for timestamps?
+# (optional, default: no)
+tsa_name		= yes	# Must the TSA name be included in the reply?
+# (optional, default: no)
+ess_cert_id_chain	= no	# Must the ESS cert id chain be included?
+# (optional, default: no)
+ess_cert_id_alg		= sha1	# algorithm to compute certificate
+# identifier (optional, default: sha1)
+[default_conf]
+ssl_conf = ssl_sect
+
+[ssl_sect]
+system_default = system_default_sect
+
+[system_default_sect]
+MinProtocol = TLSv1.2
+CipherString = DEFAULT@SECLEVEL=2


### PR DESCRIPTION
---
name: root certificate creation
about: root certificate should be created with extension BasicConstraints=CA:True

---

**Describe the change**
The Ansible plugin openssl_certificate is not able to create certs with extensions.
To achieve this I wrote a template of a config file and used command plugin instead of openssl_certificate.

**Testing**
Tested on a DigitalOcean droplet built from Debian 10 image.