### PR TITLE
Solves issue #8

### DIFF
--- a/tasks/init_ca.yml
+++ b/tasks/init_ca.yml
@@ -42,4 +42,4 @@
   openssl_privatekey:
     path: "{{ ca_path }}/{{ ca_privatekey_path }}"
     passphrase: "{{ ca_passphrase }}"
-    cipher: aes256
+    cipher: auto


### PR DESCRIPTION
---
name: Fixes ticket #8 
about: Ansible 2.10+ removed support for other crypto backends other than `cryptography`. This PR fixes an issue that popped up due to that by specifying the cipher to be used for the CA private key as `auto`.
---
**Testing**
Deployed against our infrastructure without issues.
