### PR TITLE
Allow user to specify SubjectAltName for a new certificate

### DIFF
--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -11,6 +11,9 @@
       ca_requests:
         - "{{ ansible_fqdn }}"
         - name: my_ca.example.com
+          subject_alt_name:
+            - "IP:{{ ansible_host }}"
+            - "DNS:my_ca.example.com"
           passphrase: WoNtT3L1
           cipher: aes256
           country_name: NL

--- a/tasks/requests.yml
+++ b/tasks/requests.yml
@@ -46,6 +46,8 @@
         privatekey_path: "{{ ca_path }}/{{ ca_subject_keys_path }}/{{ request.name | default(request) }}.pem"
         privatekey_passphrase: "{{ request.passphrase | default(omit) }}"
         common_name: "{{ request.name | default(request) }}"
+        subject_alt_name: "{{ request.subject_alt_name | default(omit) }}"
+        subject_alt_name_critical: "{{ true if (request.subject_alt_name | default([])) | length > 0 else false }}"
         country_name: "{{ request.country_name | default(omit) }}"
         email_address: "{{ request.email_address | default(omit) }}"
         organization_name: "{{ request.organization_name | default(omit) }}"

--- a/templates/extensions.cnf.j2
+++ b/templates/extensions.cnf.j2
@@ -4,8 +4,8 @@
 
 # These extensions are added when 'ca' signs a request.
 
-{% if item.extensions is defined %}
-{% for ext in item.extensions %}{{ ext }}{% endfor %}
+{% if request.extensions is defined %}
+{% for ext in request.extensions %}{{ ext }}{% endfor %}
 {% endif %}
 
 # This goes against PKIX guidelines but some CAs do it and some software

--- a/templates/extensions.cnf.j2
+++ b/templates/extensions.cnf.j2
@@ -57,3 +57,15 @@ authorityKeyIdentifier=keyid,issuer
 
 # This is required for TSA certificates.
 # extendedKeyUsage = critical,timeStamping
+
+{% if request.subject_alt_name is defined and request.subject_alt_name | length > 0 %}
+subjectAltName = @alt_names
+
+[alt_names]
+{% set indexes = {} %}
+{% for san in request.subject_alt_name %}
+{% set type, value = san.split(':', 1) %}
+{% set _ = indexes.update({ type: (indexes[type] | default(0)) + 1 }) %}
+{{ type }}.{{ indexes[type] }} = {{ value }}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
---
name: Allow the use of SubjectAltName
about: Instead of relying only on legacy Common Name field, allow to use SANs

---

**Describe the change**
Make use of the [subject_alt_name](https://docs.ansible.com/ansible/latest/collections/community/crypto/openssl_csr_module.html#parameter-subject_alt_name) parameter of the `community.crypto.openssl_csr` module.

I needed this change to make use of `docker buildx build --push --cache-to "type=registry,ref=private-registry:5000" ...`. Its TLS certificate was requested to a self-signed rootCA, which was provided to the server as a new CA certificate but I got this error:

```txt
ERROR: failed to solve: failed to push private-registry:5000/image-name:latest: failed to do request: Head "https://private-registry:5000/v2/image-name/blobs/sha256:<redacted>": tls: failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead
```

**Testing**

This block delivers correct certificates:

```yml
- name: Setup CA server
  hosts: ca-server
  become: true
  vars:
    ca_requests:
      - cert1
      - name: cert2
        subject_alt_name:
          - "DNS:cert.example.com"
          - "IP:{{ ansible_host }}"

  pre_tasks:
    - name: Install required packages
      ansible.builtin.package:
        name:
          - python3-cryptography
        state: present

  roles:
    - robertdebock.roles.ca
```